### PR TITLE
Add tags for product filtering step

### DIFF
--- a/extensions/product-offer-pre-purchase/src/index.js
+++ b/extensions/product-offer-pre-purchase/src/index.js
@@ -246,6 +246,7 @@ function createApp(
 }
 // [END product-offer-pre-purchase.offer-ui]
 
+// [START product-offer-pre-purchase.filter-products]
 function filterProductsOnOffer(lines, products) {
   const cartLineProductVariantIds = lines.current.map(
     (item) => item.merchandise.id
@@ -257,6 +258,7 @@ function filterProductsOnOffer(lines, products) {
     return !isProductVariantInCart;
   });
 }
+// [END product-offer-pre-purchase.filter-products]
 
 function updateProductComponents(
   product,


### PR DESCRIPTION
based on darius' feedback, we are highlighting the code to filter the products based on what's in the cart. this doesn't use shopify-specific info but we still want to draw attention to it because it completes the extension